### PR TITLE
Remove success screen before DNA step

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,17 +73,6 @@
                     </button>
                 </form>
 
-                <!-- TELA DE SUCESSO -->
-                <div class="success-screen" id="successScreen1">
-                    <div class="success-icon"></div>
-                    <h2 class="success-title">Sistema Ativado!</h2>
-                    <p class="success-message">
-                        Seu acesso foi liberado! Agora você está pronto para embarcar nesta experiência única do Voxy Mix.
-                    </p>
-                    <button class="continue-button" onclick="goToStep(2)">
-                        Entrar na Experiência
-                    </button>
-                </div>
             </div>
         </section>
 

--- a/script.js
+++ b/script.js
@@ -110,7 +110,6 @@ class VoxyMixFunnel {
         const emailInput = document.getElementById('email');
         const passwordInput = document.getElementById('password');
         const passwordSuggestion = document.getElementById('passwordSuggestion');
-        const successScreen = document.getElementById('successScreen');
 
         // Sugestão de senha
         const passwords = ['V7x#m2K9', 'P4@nW8qZ', 'M3$tR5oL', 'X9&fY2nU'];
@@ -196,18 +195,13 @@ class VoxyMixFunnel {
     }
 
     showLoginSuccess() {
-        document.querySelector('.login-form').style.display = 'none';
-        document.querySelector('.logo-section').style.display = 'none';
-        
-        const successScreen = document.getElementById('successScreen');
-        successScreen.classList.add('show');
-        
+        const form = document.querySelector('.login-form');
+        const logo = document.querySelector('.logo-section');
+        if (form) form.style.display = 'none';
+        if (logo) logo.style.display = 'none';
+
         this.audioSystem.playSuccess();
-        
-        // Botão continuar
-        document.getElementById('continueToNextStep')?.addEventListener('click', () => {
-            this.goToStep(2);
-        });
+        this.goToStep(2);
     }
 
     initKonamiCode() {

--- a/styles.css
+++ b/styles.css
@@ -419,37 +419,6 @@ body:not(.step-1) .step {
     font-weight: 600;
 }
 
-.success-screen {
-    display: none;
-    text-align: center;
-    opacity: 0;
-    transform: translateY(30px);
-}
-
-.success-screen.show {
-    display: block;
-    animation: fadeInUp 0.8s ease-out forwards;
-}
-
-.success-icon {
-    width: 100px;
-    height: 100px;
-    margin: 0 auto 2rem;
-    background: radial-gradient(circle, var(--success) 0%, var(--secondary-green) 100%);
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-shadow: var(--glow-green);
-    animation: successPulse 2s ease-in-out infinite;
-}
-
-.success-icon::before {
-    content: '✓';
-    font-size: 3rem;
-    font-weight: bold;
-    color: #ffffff;
-}
 
 /* ===== ETAPA 2: DNA MUSICAL ===== */
 .knobs-grid {


### PR DESCRIPTION
## Summary
- remove intermediate success screen from index
- skip directly to DNA step after login
- drop related CSS styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840f0cc023083229b6d006b3bbaf383